### PR TITLE
[POC] Implement weight syncing with GPU objects

### DIFF
--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -79,6 +79,9 @@ def run_ppo(config) -> None:
 @ray.remote(num_cpus=1)  # please make sure main_task is not scheduled on head
 class TaskRunner:
     def run(self, config):
+        from ray.experimental.channel.torch_tensor_type import TorchTensorType
+        TorchTensorType().register_custom_serializer()
+
         # print initial config
         from pprint import pprint
 

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -84,7 +84,7 @@ class DataParallelPPOActor(BasePPOActor):
             for key in micro_batch["multi_modal_inputs"][0].keys():
                 multi_modal_inputs[key] = torch.cat([inputs[key] for inputs in micro_batch["multi_modal_inputs"]], dim=0)
 
-        with torch.autocast(device_type=self.device_name, dtype=torch.bfloat16):
+        with torch.autocast(device_type=self.device_name, dtype=torch.float16):
             input_ids = micro_batch["input_ids"]
             batch_size, seqlen = input_ids.shape
             attention_mask = micro_batch["attention_mask"]
@@ -245,6 +245,7 @@ class DataParallelPPOActor(BasePPOActor):
             print(f"WARN: rank {torch.distributed.get_rank()} grad_norm is not finite: {grad_norm}")
             self.actor_optimizer.zero_grad()
         else:
+            # TODO: Update actor/policy model weights
             self.actor_optimizer.step()
         return grad_norm
 
@@ -431,6 +432,7 @@ class DataParallelPPOActor(BasePPOActor):
                     }
                     append_to_dict(metrics, data)
 
+                # TODO: Update actor/policy model weights
                 grad_norm = self._optimizer_step()
                 data = {"actor/grad_norm": grad_norm.detach().item()}
                 append_to_dict(metrics, data)

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -299,7 +299,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
         # `device` represents the logical device ID. For example:
         # - When CUDA_VISIBLE_DEVICES=0, device 0 maps to physical device 0
         # - When CUDA_VISIBLE_DEVICES=1, device 0 maps to physical device 1
-        # device = get_torch_device().current_device()  # used when fsdp2 set cpu_offload_policy
+        device = get_torch_device().current_device()  # used when fsdp2 set cpu_offload_policy
         # In our example, `dp_rank` is 0 - 3, and `tp_rank` is 0.
         # dp_rank = self.device_mesh["dp"].get_local_rank()
         # if dp_rank == 0:

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -81,11 +81,13 @@ class FSDPVLLMShardingManager(BaseShardingManager):
         self.load_format = load_format
         self.layered_summon = layered_summon
 
-        # Full params
+        # Full params: true only when world_size == 1
         self.full_params = full_params
         if full_params and fsdp_version(self.module) == 1:
+            print("set state_dict_type to FULL_STATE_DICT")
             FSDP.set_state_dict_type(self.module, state_dict_type=StateDictType.FULL_STATE_DICT, state_dict_config=FullStateDictConfig())
         elif fsdp_version(self.module) == 1:
+            print("set state_dict_type to SHARDED_STATE_DICT")
             FSDP.set_state_dict_type(
                 self.module,
                 state_dict_type=StateDictType.SHARDED_STATE_DICT,
@@ -175,6 +177,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
             peft_config = self.module._fsdp_wrapped_module.peft_config.get('default', None)
             params = __collect_lora_params()
         else:
+            # TODO: state_dict() is FSDP's method which may collect related params.
             params = self.module.state_dict()
         log_gpu_memory_usage("After state_dict() in sharding manager memory", logger=logger)
 


### PR DESCRIPTION
* Ray version
  * Branch: https://github.com/kevin85421/ray/tree/for-verl-weight-sync
  * Commit: 372287d41db0ecbcc720b8178311a0ecf746aa93

* Example
  * 4 Tesla T4 GPUs (16 GB memory / GPU)  
  ```sh
  PYTHONUNBUFFERED=1 RAY_DEDUP_LOGS=0 CUDA_LAUNCH_BLOCKING=1 python3 -m verl.trainer.main_ppo \
   data.train_files=$HOME/data/gsm8k/train.parquet \
   data.val_files=$HOME/data/gsm8k/test.parquet \
   data.train_batch_size=256 \
   data.max_prompt_length=512 \
   data.max_response_length=256 \
   actor_rollout_ref.model.path=Qwen/Qwen2.5-0.5B-Instruct \
   actor_rollout_ref.actor.optim.lr=1e-6 \
   actor_rollout_ref.actor.ppo_mini_batch_size=64 \
   actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=4 actor_rollout_ref.rollout.dtype=float16 actor_rollout_ref.rollout.dtype=float16 \
   actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=8 \
   actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
   actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
   actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=4 \
   critic.optim.lr=1e-5 \
   critic.model.path=Qwen/Qwen2.5-0.5B-Instruct \
   critic.ppo_micro_batch_size_per_gpu=4 \
   algorithm.kl_ctrl.kl_coef=0.001 \
   trainer.logger='[console]' \
   trainer.val_before_train=False \
   trainer.default_hdfs_dir=null \
   trainer.n_gpus_per_node=4 \
   trainer.nnodes=1 \
   trainer.save_freq=10 \
   trainer.test_freq=10 \
   trainer.total_epochs=15 2>&1 | tee verl_demo.log
  ```

* Old logic ([fsdp_vllm.py](https://github.com/volcengine/verl/blob/5aa1b046b4540ef1a7b89882175fcc979daef970/verl/workers/sharding_manager/fsdp_vllm.py#L284))
  ```python
  loaded_params = model.load_weights(((name, param.to(device, non_blocking=True).full_tensor() if isinstance(param, DTensor) else param) for name, param in updated_params.items()))
  ```
  * The `updated_params` are collected using `state_dict()`, which must be executed by every process in the process group.
  * If `param` is a `DTensor`, use `full_tensor()` to gather all shards across from 4 GPUs in our example.
  * `param.to(device, …)` moves the tensor to device 0. In each process in our example, that process has only one GPU.
  * In our example, each process has only one GPU, and every GPU holds the same tensors.
  
* New logic
  * Simulate tensor communication between two SPMD systems.
![image](https://github.com/user-attachments/assets/0af2e249-d988-4693-ba8b-c0223bb2f4df)

* Performance: Each step takes roughly 2 minutes 15 seconds, both with and without this PR.